### PR TITLE
Fix ESLint setup and template versions

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -160,16 +160,11 @@ async function run() {
       "eslint-plugin-jsx-a11y@^6.8.0",
       "typescript"
     ]);
-    await fs.writeFile(
-      ".eslintrc.json",
-      JSON.stringify({ extends: ["airbnb-extended"] }, null, 2)
-    );
   }
 
   if (usePrettier) {
     console.log(chalk.yellow("🧹 Установка Prettier"));
     await execa("npm", ["install", "-D", "prettier@^3.2.5"]);
-    await fs.writeFile(".prettierrc", JSON.stringify({ semi: true, singleQuote: true }, null, 2));
   }
 
   if (testTools.includes("jest")) {

--- a/templates/nextjs15/app/page.tsx
+++ b/templates/nextjs15/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <h1>Hello Next.js 14</h1>
+  return <h1>Hello Next.js 15</h1>
 }

--- a/templates/react18/src/main.tsx
+++ b/templates/react18/src/main.tsx
@@ -3,6 +3,6 @@ import ReactDOM from 'react-dom/client'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <h1>Hello React 19</h1>
+    <h1>Hello React 18</h1>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- prevent overwriting `.eslintrc.json` and `.prettierrc` during project creation
- update React and Next.js template greetings

## Testing
- `node -c bin/cli.js`

------
https://chatgpt.com/codex/tasks/task_e_684566f0fb5c83328d32982f3650f1c0